### PR TITLE
PR for issue-3 - replaced uglify by terser as minimizer

### DIFF
--- a/build-rollup.js
+++ b/build-rollup.js
@@ -3,7 +3,7 @@ var filesize = require("rollup-plugin-filesize")
 var typescript = require("rollup-plugin-typescript2")
 var commonjs = require("rollup-plugin-commonjs")
 var resolve = require("rollup-plugin-node-resolve")
-var uglify = require("rollup-plugin-uglify").uglify
+var terser = require("rollup-plugin-terser").terser
 var alias = require("rollup-plugin-alias")
 var replace = require("rollup-plugin-replace")
 
@@ -49,12 +49,7 @@ function build(target, mode, filename) {
     ]
 
     if (mode.endsWith(".min")) {
-        plugins.push(
-            uglify({
-                ie8: false,
-                warnings: false
-            })
-        )
+        plugins.push(terser())
     }
 
     plugins.push(filesize())
@@ -88,7 +83,7 @@ function build(target, mode, filename) {
 
 const main = async () => {
     await build("browser", "umd", "index.js")
-    // await build("browser", "umd.min", "index.min.js")
+    await build("browser", "umd.min", "index.min.js")
     await build("browser", "es", "index.module.js")
     await build("native", "cjs", "native.js")
     await build("custom", "umd", "custom.js")

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "react": "^16.7.0-alpha.0"
   },
   "devDependencies": {
-    "@types/node": "^10.0.0",
     "@types/jest": "^23.3.9",
+    "@types/node": "^10.0.0",
     "@types/react": "^16.7.2",
     "@types/react-dom": "^16.0.9",
     "husky": "^1.1.3",
@@ -57,8 +57,8 @@
     "rollup-plugin-filesize": "^5.0.1",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-replace": "^2.1.0",
+    "rollup-plugin-terser": "^3.0.0",
     "rollup-plugin-typescript2": "^0.17.2",
-    "rollup-plugin-uglify": "^6.0.0",
     "shelljs": "^0.8.2",
     "shx": "^0.3.2",
     "ts-jest": "^23.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4411,6 +4411,16 @@ rollup-plugin-replace@^2.1.0:
     minimatch "^3.0.2"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-terser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-3.0.0.tgz#045bd7cf625ee1affcfe6971dab6fffe6fb48c65"
+  integrity sha512-Ed9zRD7OoCBnh0XGlEAJle5TCUsFXMLClwKzZWnS1zbNO4MelHjfCSdFZxCAdH70M40nhZ1nRrY2GZQJhSMcjA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    jest-worker "^23.2.0"
+    serialize-javascript "^1.5.0"
+    terser "^3.8.2"
+
 rollup-plugin-typescript2@^0.17.2:
   version "0.17.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.17.2.tgz#7d18a94b74993307ec69b7c2f571c12b51561a14"
@@ -4420,16 +4430,6 @@ rollup-plugin-typescript2@^0.17.2:
     resolve "1.8.1"
     rollup-pluginutils "2.3.3"
     tslib "1.9.3"
-
-rollup-plugin-uglify@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.0.tgz#15aa8919e5cdc63b7cfc9319c781788b40084ce4"
-  integrity sha512-XtzZd159QuOaXNvcxyBcbUCSoBsv5YYWK+7ZwUyujSmISst8avRfjWlp7cGu8T2O52OJnpEBvl+D4WLV1k1iQQ==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    jest-worker "^23.2.0"
-    serialize-javascript "^1.5.0"
-    uglify-js "^3.4.9"
 
 rollup-pluginutils@2.3.3, rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.3:
   version "2.3.3"
@@ -5037,6 +5037,15 @@ terser@^3.10.0:
     source-map "~0.6.1"
     source-map-support "~0.5.6"
 
+terser@^3.8.2:
+  version "3.10.11"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.10.11.tgz#e063da74b194dde9faf0a561f3a438c549d2da3f"
+  integrity sha512-iruZ7j14oBbRYJC5cP0/vTU7YOWjN+J1ZskEGoF78tFzXdkK2hbCL/3TRZN8XB+MuvFhvOHMp7WkOCBO4VEL5g==
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
+    source-map-support "~0.5.6"
+
 test-exclude@^4.2.1:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.3.tgz#a9a5e64474e4398339245a0a769ad7c2f4a97c20"
@@ -5213,7 +5222,7 @@ typescript@^3.1.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
-uglify-js@^3.1.4, uglify-js@^3.4.9:
+uglify-js@^3.1.4:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
   integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==


### PR DESCRIPTION
@FredyC 
As discussed, I've repleace uglify by terser as minifier

FYI:
```warnings: false``` and ```ie8: false``` are default values that's why I have them removed in build-rollup.js.

Sorry for committing with a wrong issue number #1 instead of #3