### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ The React hooks don't force anyone to suddenly have a state inside a _dumb compo
 ```tsx
 import { createSelector } from 'react-selector-hooks'
 
-const userSelector = createSelector(({ user ) => ({
+const userSelector = createSelector(({ user }) => ({
     name: user.name,
     age: user.age
 }))


### PR DESCRIPTION
Not sure if this tiny typo requires a PR :-)

Added missing bracket in code example for "What about smart/dumb components?" section of README