### PR TITLE
use-observer memory leaks

### DIFF
--- a/src/useDisposable.ts
+++ b/src/useDisposable.ts
@@ -20,7 +20,7 @@ export function useDisposable<D extends TDisposable>(
     disposerGenerator: () => D,
     inputs: ReadonlyArray<any> = []
 ): D {
-    const disposerRef = useRef<D | undefined>(undefined)
+    const disposerRef = useRef<D | null>(null)
     const earlyDisposedRef = useRef(false)
 
     useEffect(() => {
@@ -52,7 +52,7 @@ export function useDisposable<D extends TDisposable>(
         return () => {
             if (disposerRef.current) {
                 disposerRef.current()
-                disposerRef.current = undefined
+                disposerRef.current = null
             }
             if (earlyDisposal) {
                 earlyDisposedRef.current = true

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,17 @@
-import { useEffect } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 const EMPTY_ARRAY: any[] = []
 
 export function useUnmount(fn: () => void) {
     useEffect(() => fn, EMPTY_ARRAY)
+}
+
+export function useForceUpdate() {
+    const [, setTick] = useState(null)
+
+    const update = useCallback(() => {
+        setTick(null)
+    }, [])
+
+    return update
 }

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -469,6 +469,26 @@ test("useImperativeMethods and forwardRef should work with useObserver", () => {
     expect(typeof cr.current!.focus).toBe("function")
 })
 
+it('should only called new Reaction once', () => {
+    let renderCount = 0;
+    // mock the Reaction class
+    const spy = jest.spyOn(mobx, 'Reaction').mockImplementation(() => (
+        { track: (fn: any) => { fn() }, dispose: () => {/* nothing */ } }
+    ))
+    const TestComponent = observer((props: any) => {
+        renderCount++
+        return (
+            <div></div>
+        )
+    })
+    const { rerender } = render(<TestComponent a="1" />)
+    rerender(<TestComponent a="2" />)
+    rerender(<TestComponent a="3" />)
+    expect(renderCount).toBe(3);
+    expect(spy.mock.calls.length).toBe(1)
+    spy.mockRestore()
+})
+
 // test("parent / childs render in the right order", done => {
 //     // See: https://jsfiddle.net/gkaemmer/q1kv7hbL/13/
 //     let events = []

--- a/test/useObservable.test.tsx
+++ b/test/useObservable.test.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react'
-import { cleanup, fireEvent, render } from 'react-testing-library'
+import * as mobx from 'mobx';
+import * as React from 'react';
+import { cleanup, fireEvent, render } from 'react-testing-library';
+import { observer, useObservable } from '../src';
 
-import { observer, useObservable } from '../src'
 
 afterEach(cleanup)
 
@@ -28,7 +29,13 @@ describe("is used to keep observable within component body", () => {
     })
 
     it("works with observer as well", () => {
+        const spyObservable = jest.spyOn(mobx, 'observable');
+
+        let renderCount = 0;
+
         const TestComponent = observer(() => {
+            renderCount++
+
             const obs = useObservable({
                 x: 1,
                 y: 2
@@ -46,6 +53,12 @@ describe("is used to keep observable within component body", () => {
         expect(div.textContent).toBe("2-2")
         fireEvent.click(div)
         expect(div.textContent).toBe("3-2")
+
+        // though render 3 times, mobx.observable only called once
+        expect(renderCount).toBe(3)
+        expect(spyObservable.mock.calls.length).toBe(1)
+
+        spyObservable.mockRestore()
     })
 
     it("actions can be used", () => {


### PR DESCRIPTION
every time we call useObserver, there is a new `new Reaction` created, but it doesn't dispose