### PR TITLE
Rethrow catched exceptions

### DIFF
--- a/src/useObserver.ts
+++ b/src/useObserver.ts
@@ -25,8 +25,14 @@ export function useObserver<T>(fn: () => T, baseComponentName = "observed"): T {
     // reaction track the observables, so that rendering
     // can be invalidated (see above) once a dependency changes
     let rendering!: T
+    let exception
     reaction.current.track(() => {
-        rendering = fn()
+        try {
+            rendering = fn()
+        } catch (e) {
+            exception = e
+        }
     })
+    if (exception) throw exception // re-throw any exceptions catched during rendering
     return rendering
 }

--- a/src/useObserver.ts
+++ b/src/useObserver.ts
@@ -33,6 +33,8 @@ export function useObserver<T>(fn: () => T, baseComponentName = "observed"): T {
             exception = e
         }
     })
-    if (exception) throw exception // re-throw any exceptions catched during rendering
+    if (exception) {
+        throw exception // re-throw any exceptions catched during rendering
+    }
     return rendering
 }

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -466,7 +466,7 @@ function runTestSuite(mode: "observer" | "useObserver") {
                 act(() => {
                     x.set(42)
                 })
-                expect(errorsSeen).toEqual(["The meaning of life!"])
+                expect(errorsSeen).toEqual(["Error: The meaning of life!"])
                 expect(rendered.container.querySelector("span")!.innerHTML).toBe("Saw error!")
             } finally {
                 // tslint:disable-next-line

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -1,3 +1,4 @@
+import mockConsole from "jest-mock-console"
 import * as mobx from "mobx"
 import * as React from "react"
 import { act, cleanup, fireEvent, render } from "react-testing-library"
@@ -450,12 +451,7 @@ function runTestSuite(mode: "observer" | "useObserver") {
                 return <span>{x.get()}</span>
             })
 
-            // tslint:disable-next-line
-            const origErrorLogger = console.error
-            // tslint:disable-next-line
-            console.error = function() {
-                // supress printing warnings that React always prints in DEV, even with error boundaries...
-            }
+            const restoreConsole = mockConsole()
             try {
                 const rendered = render(
                     <ErrorBoundary>
@@ -469,8 +465,7 @@ function runTestSuite(mode: "observer" | "useObserver") {
                 expect(errorsSeen).toEqual(["Error: The meaning of life!"])
                 expect(rendered.container.querySelector("span")!.innerHTML).toBe("Saw error!")
             } finally {
-                // tslint:disable-next-line
-                console.error = origErrorLogger
+                restoreConsole()
             }
         })
     })

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -423,16 +423,16 @@ function runTestSuite(mode: "observer" | "useObserver") {
             const errorsSeen: any[] = []
 
             class ErrorBoundary extends React.Component {
+                public static getDerivedStateFromError() {
+                    return { hasError: true }
+                }
+
                 public state = {
                     hasError: false
                 }
 
                 public componentDidCatch(error: any, info: any) {
                     errorsSeen.push("" + error)
-                }
-
-                public static getDerivedStateFromError() {
-                    return { hasError: true }
                 }
 
                 public render() {
@@ -450,6 +450,7 @@ function runTestSuite(mode: "observer" | "useObserver") {
                 return <span>{x.get()}</span>
             })
 
+            // tslint:disable-next-line
             const origErrorLogger = console.error
             // tslint:disable-next-line
             console.error = function() {

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -436,7 +436,7 @@ function runTestSuite(mode: "observer" | "useObserver") {
                 }
 
                 render() {
-                    if (this.state.hasError) return null
+                    if (this.state.hasError) return <span>Saw error!</span>
                     return this.props.children
                 }
             }
@@ -459,6 +459,7 @@ function runTestSuite(mode: "observer" | "useObserver") {
                     x.set(42)
                 })
                 expect(errorsSeen).toEqual(["The meaning of life!"])
+                expect(rendered.container.querySelector("span")!.innerHTML).toBe("Saw error!")
             } finally {
                 console.error = origErrorLogger
             }


### PR DESCRIPTION
See #53, exceptions catched by MobX's Reaction are now catched and rethrown, rather than just logged.