### PR TITLE
Add test for proper reaction disposal in StrictMode

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
-
-const EMPTY_ARRAY: any[] = []
-
-export function useUnmount(fn: () => void) {
-    useEffect(() => fn, EMPTY_ARRAY)
-}
+import { useCallback, useState } from "react"
 
 export function useForceUpdate() {
     const [, setTick] = useState(0)

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -116,21 +116,6 @@ function runTestSuite(mode: "observer" | "useObserver") {
     })
 
     describe("double-rendering/StrictMode behavior", () => {
-        // tslint:disable: no-console
-        let originalConsoleError: typeof console.error
-        const consoleErrors: any[] = []
-        beforeEach(() => {
-            originalConsoleError = console.error
-            console.error = (msg: any, ...args: any[]) => {
-                consoleErrors.push(msg)
-                originalConsoleError.call(console, msg, ...args)
-            }
-        })
-        afterEach(() => {
-            console.error = originalConsoleError
-        })
-        // tslint:enable: no-console
-
         test("rendering and unmounting disposes of reactions fully", () => {
             const store = mobx.observable({ count: 0 })
 
@@ -152,12 +137,18 @@ function runTestSuite(mode: "observer" | "useObserver") {
             // Trigger a change to the observable. If the reactions were
             // not disposed correctly, we'll see some console errors from
             // React StrictMode.
-            act(() => {
-                store.count++
-            })
+            const restoreConsole = mockConsole()
+            try {
+                act(() => {
+                    store.count++
+                })
 
-            // Check to see if any console errors were reported.
-            expect(consoleErrors).toEqual([])
+                // Check to see if any console errors were reported.
+                // tslint:disable-next-line: no-console
+                expect(console.error).not.toHaveBeenCalled()
+            } finally {
+                restoreConsole()
+            }
         })
     })
 

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -115,43 +115,6 @@ function runTestSuite(mode: "observer" | "useObserver") {
         })
     })
 
-    describe("double-rendering/StrictMode behavior", () => {
-        test("rendering and unmounting disposes of reactions fully", () => {
-            const store = mobx.observable({ count: 0 })
-
-            const TestComponent = obsComponent(function RawComponent() {
-                return <div>{store.count}</div>
-            })
-
-            // Render our observing component wrapped in StrictMode
-            const rendering = render(
-                <React.StrictMode>
-                    <TestComponent />
-                </React.StrictMode>
-            )
-
-            // That will have caused our component to have been rendered
-            // more than once, but when we unmount it'll only unmount once.
-            rendering.unmount()
-
-            // Trigger a change to the observable. If the reactions were
-            // not disposed correctly, we'll see some console errors from
-            // React StrictMode.
-            const restoreConsole = mockConsole()
-            try {
-                act(() => {
-                    store.count++
-                })
-
-                // Check to see if any console errors were reported.
-                // tslint:disable-next-line: no-console
-                expect(console.error).not.toHaveBeenCalled()
-            } finally {
-                restoreConsole()
-            }
-        })
-    })
-
     describe("isObjectShallowModified detects when React will update the component", () => {
         const store = mobx.observable({ count: 0 })
         let counterRenderings = 0

--- a/test/useObserver.test.tsx
+++ b/test/useObserver.test.tsx
@@ -1,0 +1,42 @@
+import mockConsole from "jest-mock-console"
+import * as mobx from "mobx"
+import * as React from "react"
+import { act, cleanup, render } from "react-testing-library"
+
+import { useObserver } from "../src"
+
+afterEach(cleanup)
+
+test("uncommitted observing components should not attempt state changes", () => {
+    const store = mobx.observable({ count: 0 })
+
+    const TestComponent = () => useObserver(() => <div>{store.count}</div>)
+
+    // Render our observing component wrapped in StrictMode
+    const rendering = render(
+        <React.StrictMode>
+            <TestComponent />
+        </React.StrictMode>
+    )
+
+    // That will have caused our component to have been rendered
+    // more than once, but when we unmount it'll only unmount once.
+    rendering.unmount()
+
+    // Trigger a change to the observable. If the reactions were
+    // not disposed correctly, we'll see some console errors from
+    // React StrictMode because we're calling state mutators to
+    // trigger an update.
+    const restoreConsole = mockConsole()
+    try {
+        act(() => {
+            store.count++
+        })
+
+        // Check to see if any console errors were reported.
+        // tslint:disable-next-line: no-console
+        expect(console.error).not.toHaveBeenCalled()
+    } finally {
+        restoreConsole()
+    }
+})

--- a/test/useObserver.test.tsx
+++ b/test/useObserver.test.tsx
@@ -40,25 +40,3 @@ test("uncommitted observing components should not attempt state changes", () => 
         restoreConsole()
     }
 })
-
-test("uncommitted components should not leak observations", () => {
-    const store = mobx.observable({ count: 0 })
-
-    // Track whether count is observed
-    let countIsObserved = false
-    mobx.onBecomeObserved(store, "count", () => (countIsObserved = true))
-    mobx.onBecomeUnobserved(store, "count", () => (countIsObserved = false))
-
-    const TestComponent = () => useObserver(() => <div>{store.count}</div>)
-
-    // Render and unmount
-    const rendering = render(
-        <React.StrictMode>
-            <TestComponent />
-        </React.StrictMode>
-    )
-    rendering.unmount()
-
-    // We've unmounted so there should be no outstanding observations of count.
-    expect(countIsObserved).toBeFalsy()
-})


### PR DESCRIPTION
This is a PR for a test to illustrate the issue with Concurrent Mode (and, more problematic, in StrictMode), as requested in https://github.com/mobxjs/mobx-react-lite/issues/53#issuecomment-460363116

(It currently fails, so you may not want to merge this right now...)
