### PR TITLE
Schedule uncommitted reaction cleanup

### DIFF
--- a/src/useObserver.ts
+++ b/src/useObserver.ts
@@ -36,11 +36,13 @@ export function useObserver<T>(
                 forceUpdate()
             }
         })
+        scheduleCleanupOfReactionIfNotCommitted(reaction.current)
     }
 
     useDebugValue(reaction, printDebugValue)
 
     useEffect(() => {
+        recordReactionAsCommitted(reaction.current!)
         committed.current = true
         return () => reaction.current!.dispose()
     }, [])
@@ -62,4 +64,54 @@ export function useObserver<T>(
         throw exception // re-throw any exceptions catched during rendering
     }
     return rendering
+}
+
+/**
+ * Reactions created by components that have yet to be committed.
+ */
+const uncommittedReactions: Reaction[] = []
+
+/**
+ * Latest 'uncommitted reactions' cleanup timer handle
+ */
+let reactionCleanupHandle: number | undefined
+
+function scheduleCleanupOfReactionIfNotCommitted(reaction: Reaction) {
+    uncommittedReactions.push(reaction)
+    if (!reactionCleanupHandle) {
+        // We currently have no cleanup timer running; schedule one
+        reactionCleanupHandle = window.setTimeout(cleanUncommittedReactions, 100)
+    }
+}
+
+function recordReactionAsCommitted(reaction: Reaction) {
+    // It would be more efficient if we could use a Set instead of an Array,
+    // but mobx-react-lite currently supports MobX 4 and ES5, so we can't assume
+    // the presence of Set.
+    const i = uncommittedReactions.indexOf(reaction)
+    if (i) {
+        uncommittedReactions.splice(i, 1)
+    }
+}
+
+/**
+ * Run by the cleanup timer to dispose any outstanding reactions
+ */
+function cleanUncommittedReactions() {
+    reactionCleanupHandle = undefined
+
+    while (uncommittedReactions.length) {
+        uncommittedReactions.pop()!.dispose()
+    }
+}
+
+/**
+ * Only to be used by test functions; do not export outside of mobx-react-lite
+ */
+export function resetCleanupScheduleForTests() {
+    if (reactionCleanupHandle) {
+        clearTimeout(reactionCleanupHandle)
+        reactionCleanupHandle = undefined
+    }
+    uncommittedReactions.length = 0
 }

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -116,21 +116,6 @@ function runTestSuite(mode: "observer" | "useObserver") {
     })
 
     describe("double-rendering/StrictMode behavior", () => {
-        // tslint:disable: no-console
-        let originalConsoleError: typeof console.error
-        const consoleErrors: any[] = []
-        beforeEach(() => {
-            originalConsoleError = console.error
-            console.error = (msg: any, ...args: any[]) => {
-                consoleErrors.push(msg)
-                originalConsoleError.call(console, msg, ...args)
-            }
-        })
-        afterEach(() => {
-            console.error = originalConsoleError
-        })
-        // tslint:enable: no-console
-
         test("rendering and unmounting disposes of reactions fully", () => {
             const store = mobx.observable({ count: 0 })
 
@@ -152,12 +137,18 @@ function runTestSuite(mode: "observer" | "useObserver") {
             // Trigger a change to the observable. If the reactions were
             // not disposed correctly, we'll see some console errors from
             // React StrictMode.
-            act(() => {
-                store.count++
-            })
+            const restoreConsole = mockConsole()
+            try {
+                act(() => {
+                    store.count++
+                })
 
-            // Check to see if any console errors were reported.
-            expect(consoleErrors).toEqual([])
+                // Check to see if any console errors were reported.
+                // tslint:disable-next-line: no-console
+                expect(console.error).not.toHaveBeenCalled()
+            } finally {
+                restoreConsole()
+            }
         })
     })
 

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -115,43 +115,6 @@ function runTestSuite(mode: "observer" | "useObserver") {
         })
     })
 
-    describe("double-rendering/StrictMode behavior", () => {
-        test("rendering and unmounting disposes of reactions fully", () => {
-            const store = mobx.observable({ count: 0 })
-
-            const TestComponent = obsComponent(function RawComponent() {
-                return <div>{store.count}</div>
-            })
-
-            // Render our observing component wrapped in StrictMode
-            const rendering = render(
-                <React.StrictMode>
-                    <TestComponent />
-                </React.StrictMode>
-            )
-
-            // That will have caused our component to have been rendered
-            // more than once, but when we unmount it'll only unmount once.
-            rendering.unmount()
-
-            // Trigger a change to the observable. If the reactions were
-            // not disposed correctly, we'll see some console errors from
-            // React StrictMode.
-            const restoreConsole = mockConsole()
-            try {
-                act(() => {
-                    store.count++
-                })
-
-                // Check to see if any console errors were reported.
-                // tslint:disable-next-line: no-console
-                expect(console.error).not.toHaveBeenCalled()
-            } finally {
-                restoreConsole()
-            }
-        })
-    })
-
     describe("isObjectShallowModified detects when React will update the component", () => {
         const store = mobx.observable({ count: 0 })
         let counterRenderings = 0

--- a/test/useObserver.test.tsx
+++ b/test/useObserver.test.tsx
@@ -1,0 +1,42 @@
+import mockConsole from "jest-mock-console"
+import * as mobx from "mobx"
+import * as React from "react"
+import { act, cleanup, render } from "react-testing-library"
+
+import { useObserver } from "../src"
+
+afterEach(cleanup)
+
+test("uncommitted observing components should not attempt state changes", () => {
+    const store = mobx.observable({ count: 0 })
+
+    const TestComponent = () => useObserver(() => <div>{store.count}</div>)
+
+    // Render our observing component wrapped in StrictMode
+    const rendering = render(
+        <React.StrictMode>
+            <TestComponent />
+        </React.StrictMode>
+    )
+
+    // That will have caused our component to have been rendered
+    // more than once, but when we unmount it'll only unmount once.
+    rendering.unmount()
+
+    // Trigger a change to the observable. If the reactions were
+    // not disposed correctly, we'll see some console errors from
+    // React StrictMode because we're calling state mutators to
+    // trigger an update.
+    const restoreConsole = mockConsole()
+    try {
+        act(() => {
+            store.count++
+        })
+
+        // Check to see if any console errors were reported.
+        // tslint:disable-next-line: no-console
+        expect(console.error).not.toHaveBeenCalled()
+    } finally {
+        restoreConsole()
+    }
+})

--- a/test/useObserver.test.tsx
+++ b/test/useObserver.test.tsx
@@ -40,25 +40,3 @@ test("uncommitted observing components should not attempt state changes", () => 
         restoreConsole()
     }
 })
-
-test("uncommitted components should not leak observations", () => {
-    const store = mobx.observable({ count: 0 })
-
-    // Track whether count is observed
-    let countIsObserved = false
-    mobx.onBecomeObserved(store, "count", () => (countIsObserved = true))
-    mobx.onBecomeUnobserved(store, "count", () => (countIsObserved = false))
-
-    const TestComponent = () => useObserver(() => <div>{store.count}</div>)
-
-    // Render and unmount
-    const rendering = render(
-        <React.StrictMode>
-            <TestComponent />
-        </React.StrictMode>
-    )
-    rendering.unmount()
-
-    // We've unmounted so there should be no outstanding observations of count.
-    expect(countIsObserved).toBeFalsy()
-})

--- a/test/useObserver.test.tsx
+++ b/test/useObserver.test.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { act, cleanup, render } from "react-testing-library"
 
 import { useObserver } from "../src"
+import { resetCleanupScheduleForTests } from "../src/useObserver"
 
 afterEach(cleanup)
 
@@ -39,4 +40,44 @@ test("uncommitted observing components should not attempt state changes", () => 
     } finally {
         restoreConsole()
     }
+})
+
+test("uncommitted components should not leak observations", async () => {
+    resetCleanupScheduleForTests()
+
+    jest.useFakeTimers()
+
+    const store = mobx.observable({ count1: 0, count2: 0 })
+
+    // Track whether counts are observed
+    let count1IsObserved = false
+    let count2IsObserved = false
+    mobx.onBecomeObserved(store, "count1", () => (count1IsObserved = true))
+    mobx.onBecomeUnobserved(store, "count1", () => (count1IsObserved = false))
+    mobx.onBecomeObserved(store, "count2", () => (count2IsObserved = true))
+    mobx.onBecomeUnobserved(store, "count2", () => (count2IsObserved = false))
+
+    const TestComponent1 = () => useObserver(() => <div>{store.count1}</div>)
+    const TestComponent2 = () => useObserver(() => <div>{store.count2}</div>)
+
+    // Render, then remove only #2
+    const rendering = render(
+        <React.StrictMode>
+            <TestComponent1 />
+            <TestComponent2 />
+        </React.StrictMode>
+    )
+    rendering.rerender(
+        <React.StrictMode>
+            <TestComponent1 />
+        </React.StrictMode>
+    )
+
+    // Allow any reaction-disposal cleanup timers to run
+    jest.runAllTimers()
+
+    // count1 should still be being observed by Component1,
+    // but count2 should have had its reaction cleaned up.
+    expect(count1IsObserved).toBeTruthy()
+    expect(count2IsObserved).toBeFalsy()
 })


### PR DESCRIPTION
This PR builds on PR #119 and introduces some fixes for #53:

- a unit test for checking that reactions are properly disposed for components that were double-rendered before being committed (e.g. by ConcurrentMode or StrictMode).
- a fix which schedules the cleanup of such reactions.

Note that there's one aspect I'm unsure of, both of how to test or fix in a nice way, so I'm pushing this up for feedback.  cc: @mweststrate, @FredyC

The happy day case, which I've tested for, and coded for:

1. render phase 1:
    1. Component instance A gets rendered, creating reaction R1, which we track
    1. we trigger a timer to check for leaked reactions
    1. rendering is aborted and restarts, or StrictMode triggers a second render in order to root out trouble
    1. Component instance A gets rendered, creating reaction R2, which we track
1. commit phase 1:
    1. Component instance A commits, and we remove R2 from the 'leaked reactions' list
1. render phase 2:
    1. Component instance B gets rendered, creating reaction R3, which we track
    1. second render triggered
    1. Component instance B gets rendered, creating reaction R4, which we track
1. commit phase 2:
    1. Component instance B commits, and we remove R4 from the 'leaked reactions' list
1. cleanup timer ticks:
    1. R1 and R3 are disposed. All is well. Everybody is happy.


But there's an edge case I'm concerned about (which is why I don't think that this PR is sufficient). What if it's been a while since the timer was kicked off, but _the latest render phase hasn't had a corresponding commit phase yet_?

1. render phase 1:
    1. Component instance A gets rendered, creating reaction R1, which we track
    1. we trigger a timer to check for leaked reactions
    1. rendering is aborted and restarts, or StrictMode triggers a second render in order to root out trouble
    1. Component instance A gets rendered, creating reaction R2, which we track
1. commit phase 1:
    1. Component instance A commits, and we remove R2 from the 'leaked reactions' list
1. render phase 2:
    1. Component instance B gets rendered, creating reaction R3, which we track
    1. second render triggered
    1. Component instance B gets rendered, creating reaction R4, which we track
1. cleanup timer ticks (between render and commit - this _can_ happen, right?) :
    1. R1, R3 and R4 are disposed
1. commit phase 2:
    1. Component instance A commits, and the world ends because R4 has previously been disposed by the cleanup schedule

I _think_, to do this properly, we need to record that a reaction is safe to clean up only once a commit phase has happened?
