### PR TITLE
use transaction instead of action to avoid untrackable local methods

### DIFF
--- a/src/useLocalStore.ts
+++ b/src/useLocalStore.ts
@@ -1,6 +1,15 @@
-import { action, observable } from "mobx"
+import { observable, transaction } from "mobx"
 import { useState } from "react"
 import { isPlainObject } from "./utils"
+
+// tslint:disable-next-line: ban-types
+function wrapInTransaction(fn: Function) {
+    // tslint:disable-next-line: only-arrow-functions
+    return function() {
+        const args = arguments
+        return transaction(() => fn.apply(null, args))
+    }
+}
 
 export function useLocalStore<T>(initializer: () => T): T {
     return useState(() => {
@@ -9,7 +18,7 @@ export function useLocalStore<T>(initializer: () => T): T {
             Object.keys(store).forEach(key => {
                 const value = store[key]
                 if (typeof value === "function") {
-                    store[key] = action(value.bind(store))
+                    store[key] = wrapInTransaction(value.bind(store))
                 }
             })
         }


### PR DESCRIPTION
Actions are untrackable in MobX, this means that calling a local function from a computed wouldn't be tracked (this was exposed by the test "computed properties can use local functions"). So auto wrapping in `action` is dropped in this PR. 

However, without action, the function don't execute in a single transaction (this was exposed by the test "transactions are respected"). using the low-level `transaction` primitive fixes that.