### PR TITLE
Allow to pass props to useLocalStore

### DIFF
--- a/src/useComputed.ts
+++ b/src/useComputed.ts
@@ -7,7 +7,9 @@ export function useComputed<T>(func: () => T, inputs: ReadonlyArray<any> = []): 
     if (process.env.NODE_ENV !== "production" && !warned) {
         warned = true
         // tslint:disable-next-line: no-console
-        console.warn("[mobx-react-lite] useComputed has been deprecated. Use useLocalStore instead.")
+        console.warn(
+            "[mobx-react-lite] useComputed has been deprecated. Use useLocalStore instead."
+        )
     }
     const computed = useMemo(() => mobx.computed(func), inputs)
     return computed.get()

--- a/src/useDisposable.ts
+++ b/src/useDisposable.ts
@@ -25,7 +25,9 @@ export function useDisposable<D extends TDisposable>(
     if (process.env.NODE_ENV !== "production" && !warned) {
         warned = true
         // tslint:disable-next-line: no-console
-        console.warn("[mobx-react-lite] useDisposable has been deprecated. Use React.useEffect instead.")
+        console.warn(
+            "[mobx-react-lite] useDisposable has been deprecated. Use React.useEffect instead."
+        )
     }
     const disposerRef = useRef<D | null>(null)
     const earlyDisposedRef = useRef(false)

--- a/src/useLocalStore.ts
+++ b/src/useLocalStore.ts
@@ -11,26 +11,13 @@ function wrapInTransaction(fn: Function) {
     }
 }
 
-export function useLocalStore<T>(initializer: (props?: any) => T, props?: any): T {
-    const [res] = useState(() => (props ? observable(props, {}, { deep: false }) : {}))
-
-    if (typeof props !== "undefined") {
-        if (process.env.NODE_ENV !== "production" && !isPlainObject(props)) {
-            throw new Error("useLocalStore expects an object as second argument")
+export function useLocalStore<T>(initializer: (props?: any) => T, current?: any): T {
+    const local = useState(() => {
+        let props
+        if (isPlainObject(current)) {
+            props = observable(current, {}, { deep: false })
         }
-
-        if (
-            process.env.NODE_ENV !== "production" &&
-            Object.keys(res).length !== Object.keys(props).length
-        ) {
-            throw new Error("the shape of props passed to useLocalStore should be stable")
-        }
-
-        Object.assign(res, props)
-    }
-
-    return useState(() => {
-        const store: any = observable(initializer(res))
+        const store: any = observable(initializer(props))
         if (isPlainObject(store)) {
             Object.keys(store).forEach(key => {
                 const value = store[key]
@@ -39,6 +26,20 @@ export function useLocalStore<T>(initializer: (props?: any) => T, props?: any): 
                 }
             })
         }
-        return store
+        return { store, props }
     })[0]
+
+    if (isPlainObject(current)) {
+        if (
+            process.env.NODE_ENV !== "production" &&
+            Object.keys(local.props).length !== Object.keys(current).length
+        ) {
+            throw new Error("the shape of props passed to useLocalStore should be stable")
+        }
+        Object.assign(local.props, current)
+    } else if (process.env.NODE_ENV !== "production" && typeof current !== "undefined") {
+        throw new Error("useLocalStore expects an object as second argument")
+    }
+
+    return local.store
 }

--- a/src/useLocalStore.ts
+++ b/src/useLocalStore.ts
@@ -1,5 +1,5 @@
 import { observable, transaction } from "mobx"
-import { useMemo } from "react"
+import { useState } from "react"
 import { isPlainObject } from "./utils"
 
 // tslint:disable-next-line: ban-types
@@ -12,7 +12,7 @@ function wrapInTransaction(fn: Function) {
 }
 
 export function useLocalStore<T>(initializer: (props?: any) => T, props?: any): T {
-    const res = useMemo(() => (props ? observable(props, {}, { deep: false }) : {}), [])
+    const [res] = useState(() => (props ? observable(props, {}, { deep: false }) : {}))
 
     if (typeof props !== "undefined") {
         if (process.env.NODE_ENV !== "production" && !isPlainObject(props)) {
@@ -29,7 +29,7 @@ export function useLocalStore<T>(initializer: (props?: any) => T, props?: any): 
         Object.assign(res, props)
     }
 
-    return useMemo(() => {
+    return useState(() => {
         const store: any = observable(initializer(res))
         if (isPlainObject(store)) {
             Object.keys(store).forEach(key => {
@@ -40,5 +40,5 @@ export function useLocalStore<T>(initializer: (props?: any) => T, props?: any): 
             })
         }
         return store
-    }, [])
+    })[0]
 }

--- a/test/useLocalStore.test.tsx
+++ b/test/useLocalStore.test.tsx
@@ -1,9 +1,11 @@
+import mockConsole from "jest-mock-console"
 import * as mobx from "mobx"
 import * as React from "react"
+import { renderHook } from "react-hooks-testing-library"
 import { act, cleanup, fireEvent, render } from "react-testing-library"
 
-import { observer, useLocalStore, useObserver } from "../src"
-import { useEffect } from "react"
+import { Observer, observer, useLocalStore, useObserver } from "../src"
+import { useEffect, useState } from "react"
 import { autorun } from "mobx"
 
 afterEach(cleanup)
@@ -236,4 +238,210 @@ describe("is used to keep observable within component body", () => {
         fireEvent.click(div)
         expect(div.textContent).toBe("initial - 10later - 20")
     })
+
+    describe("with props", () => {
+        it("and useObserver", () => {
+            let counterRender = 0
+            let observerRender = 0
+
+            function Counter({ multiplier }: { multiplier: number }) {
+                counterRender++
+
+                const store = useLocalStore(props => ({
+                    count: 10,
+                    get multiplied() {
+                        return props.multiplier * this.count
+                    },
+                    inc() {
+                        this.count += 1
+                    }
+                }), { multiplier })
+
+                return useObserver(
+                    () => (
+                        observerRender++,
+                        (
+                            <div>
+                                Multiplied count: <span>{store.multiplied}</span>
+                                <button id="inc" onClick={store.inc}>
+                                    Increment
+                                </button>
+                            </div>
+                        )
+                    )
+                )
+            }
+
+            function Parent() {
+                const [multiplier, setMultiplier] = useState(1)
+
+                return (
+                    <div>
+                        <Counter multiplier={multiplier} />
+                        <button id="incmultiplier" onClick={() => setMultiplier(m => m + 1)} />
+                    </div>
+                )
+            }
+
+            const { container } = render(<Parent />)
+
+            expect(container.querySelector("span")!.innerHTML).toBe("10")
+            expect(counterRender).toBe(1)
+            expect(observerRender).toBe(1)
+
+            act(() => {
+                ;(container.querySelector("#inc")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("11")
+            expect(counterRender).toBe(2) // 1 would be better!
+            expect(observerRender).toBe(2)
+
+            act(() => {
+                ;(container.querySelector("#incmultiplier")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("22")
+            expect(counterRender).toBe(4) // TODO: avoid double rendering here!
+            expect(observerRender).toBe(4) // TODO: avoid double rendering here!
+        })
+
+        it("with <Observer>", () => {
+            let counterRender = 0
+            let observerRender = 0
+
+            function Counter({ multiplier }: { multiplier: number }) {
+                counterRender++
+
+                const store = useLocalStore(props => ({
+                    count: 10,
+                    get multiplied() {
+                        return props.multiplier * this.count
+                    },
+                    inc() {
+                        this.count += 1
+                    }
+                }), { multiplier })
+
+                return (
+                    <Observer>
+                        {() => {
+                            observerRender++
+                            return (
+                                <div>
+                                    Multiplied count: <span>{store.multiplied}</span>
+                                    <button id="inc" onClick={store.inc}>
+                                        Increment
+                                    </button>
+                                </div>
+                            )
+                        }}
+                    </Observer>
+                )
+            }
+
+            function Parent() {
+                const [multiplier, setMultiplier] = useState(1)
+
+                return (
+                    <div>
+                        <Counter multiplier={multiplier} />
+                        <button id="incmultiplier" onClick={() => setMultiplier(m => m + 1)} />
+                    </div>
+                )
+            }
+
+            const { container } = render(<Parent />)
+
+            expect(container.querySelector("span")!.innerHTML).toBe("10")
+            expect(counterRender).toBe(1)
+            expect(observerRender).toBe(1)
+
+            act(() => {
+                ;(container.querySelector("#inc")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("11")
+            expect(counterRender).toBe(1)
+            expect(observerRender).toBe(2)
+
+            act(() => {
+                ;(container.querySelector("#incmultiplier")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("22")
+            expect(counterRender).toBe(2)
+            expect(observerRender).toBe(3)
+        })
+
+        it("with observer()", () => {
+            let counterRender = 0
+
+            const Counter = observer(({ multiplier }: { multiplier: number }) => {
+                counterRender++
+
+                const store = useLocalStore(props => ({
+                    count: 10,
+                    get multiplied() {
+                        return props.multiplier * this.count
+                    },
+                    inc() {
+                        this.count += 1
+                    }
+                }), { multiplier })
+
+                return (
+                    <div>
+                        Multiplied count: <span>{store.multiplied}</span>
+                        <button id="inc" onClick={store.inc}>
+                            Increment
+                        </button>
+                    </div>
+                )
+            })
+
+            function Parent() {
+                const [multiplier, setMultiplier] = useState(1)
+
+                return (
+                    <div>
+                        <Counter multiplier={multiplier} />
+                        <button id="incmultiplier" onClick={() => setMultiplier(m => m + 1)} />
+                    </div>
+                )
+            }
+
+            const { container } = render(<Parent />)
+
+            expect(container.querySelector("span")!.innerHTML).toBe("10")
+            expect(counterRender).toBe(1)
+
+            act(() => {
+                ;(container.querySelector("#inc")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("11")
+            expect(counterRender).toBe(2)
+
+            act(() => {
+                ;(container.querySelector("#incmultiplier")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("22")
+            expect(counterRender).toBe(4) // TODO: should be 3
+        })
+    })
+
+
+    it("checks for plain object being passed in", () => {
+        const restore = mockConsole() // to ignore React showing caught errors
+        const { result } = renderHook(() => {
+            useLocalStore(props => ({
+                count: 10,
+                inc() {
+                    this.count += 1
+                }
+            }), false)
+        })
+
+        expect(result.error).toMatchInlineSnapshot(
+            `[Error: useLocalStore expects an object as second argument]`
+        )
+        restore()
+    })
+
 })


### PR DESCRIPTION
As I commented in #94 I believe useAsObservableSource is not necessary if its sole purpose is supporting using props in useLocalStore. This PR adds this functionality directly to useLocalStore:

Example:

```es6
function Counter({ multiplier }) {
    const store = useLocalStore(props => ({
        count: 0,
        get multiplied() {
            return props.multiplier * this.count
        },
        inc() {
            this.count += 1
        }
    }), { multiplier })

    return (
        <Observer>
            {() => (
                <div>
                    Multiplied count: {store.multiplied}
                    <button onClick={store.inc}>Increment</button>
                </div>
            )}
        </Observer>
    )
}
```