### PR TITLE
UMD builds registers module as mobxReactLite in global namespace

### DIFF
--- a/build-rollup.js
+++ b/build-rollup.js
@@ -74,7 +74,7 @@ function build(target, mode, filename) {
                     "react-native": "ReactNative",
                     mobx: "mobx"
                 },
-                name: "mobxReact",
+                name: "mobxReactLite",
                 exports: "named"
             }
 


### PR DESCRIPTION
instead of `mobxReact` which collides with `mobx-react` lib.

closes: https://github.com/mobxjs/mobx-react-lite/issues/148