### PR TITLE
Allow to pass source to useLocalStore 

### DIFF
--- a/src/useAsObservableSource.ts
+++ b/src/useAsObservableSource.ts
@@ -1,20 +1,33 @@
 import { observable } from "mobx"
-import { useState } from "react"
+import React from "react"
 
 import { isPlainObject } from "./utils"
 
-export function useAsObservableSource<T>(current: T): T {
+export function useAsObservableSourceInternal<TSource>(
+    current: TSource,
+    usedByLocalStore: boolean
+): TSource {
+    const culprit = usedByLocalStore ? "useLocalStore" : "useAsObservableSource"
+    if (usedByLocalStore && current === undefined) {
+        return undefined as any
+    }
     if (process.env.NODE_ENV !== "production" && !isPlainObject(current)) {
-        throw new Error("useAsObservableSource expects an object as first argument")
+        throw new Error(
+            `${culprit} expects a plain object as ${usedByLocalStore ? "second" : "first"} argument`
+        )
     }
 
-    const [res] = useState(() => observable(current, {}, { deep: false }))
+    const [res] = React.useState(() => observable(current, {}, { deep: false }))
     if (
         process.env.NODE_ENV !== "production" &&
         Object.keys(res).length !== Object.keys(current).length
     ) {
-        throw new Error("the shape of objects passed to useAsObservableSource should be stable")
+        throw new Error(`the shape of objects passed to ${culprit} should be stable`)
     }
     Object.assign(res, current)
     return res
+}
+
+export function useAsObservableSource<TSource>(current: TSource): TSource {
+    return useAsObservableSourceInternal(current, false)
 }

--- a/src/useComputed.ts
+++ b/src/useComputed.ts
@@ -7,7 +7,9 @@ export function useComputed<T>(func: () => T, inputs: ReadonlyArray<any> = []): 
     if (process.env.NODE_ENV !== "production" && !warned) {
         warned = true
         // tslint:disable-next-line: no-console
-        console.warn("[mobx-react-lite] useComputed has been deprecated. Use useLocalStore instead.")
+        console.warn(
+            "[mobx-react-lite] useComputed has been deprecated. Use useLocalStore instead."
+        )
     }
     const computed = useMemo(() => mobx.computed(func), inputs)
     return computed.get()

--- a/src/useDisposable.ts
+++ b/src/useDisposable.ts
@@ -25,7 +25,9 @@ export function useDisposable<D extends TDisposable>(
     if (process.env.NODE_ENV !== "production" && !warned) {
         warned = true
         // tslint:disable-next-line: no-console
-        console.warn("[mobx-react-lite] useDisposable has been deprecated. Use React.useEffect instead.")
+        console.warn(
+            "[mobx-react-lite] useDisposable has been deprecated. Use React.useEffect instead."
+        )
     }
     const disposerRef = useRef<D | null>(null)
     const earlyDisposedRef = useRef(false)

--- a/src/useLocalStore.ts
+++ b/src/useLocalStore.ts
@@ -11,9 +11,13 @@ function wrapInTransaction(fn: Function) {
     }
 }
 
-export function useLocalStore<T>(initializer: () => T): T {
-    return useState(() => {
-        const store: any = observable(initializer())
+export function useLocalStore<T>(initializer: (props?: any) => T, current?: any): T {
+    const local = useState(() => {
+        let props
+        if (isPlainObject(current)) {
+            props = observable(current, {}, { deep: false })
+        }
+        const store: any = observable(initializer(props))
         if (isPlainObject(store)) {
             Object.keys(store).forEach(key => {
                 const value = store[key]
@@ -22,6 +26,20 @@ export function useLocalStore<T>(initializer: () => T): T {
                 }
             })
         }
-        return store
+        return { store, props }
     })[0]
+
+    if (isPlainObject(current)) {
+        if (
+            process.env.NODE_ENV !== "production" &&
+            Object.keys(local.props).length !== Object.keys(current).length
+        ) {
+            throw new Error("the shape of props passed to useLocalStore should be stable")
+        }
+        Object.assign(local.props, current)
+    } else if (process.env.NODE_ENV !== "production" && typeof current !== "undefined") {
+        throw new Error("useLocalStore expects an object as second argument")
+    }
+
+    return local.store
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export function useForceUpdate() {
     return update
 }
 
-export function isPlainObject(value: any): boolean {
+export function isPlainObject(value: any): value is object {
     if (!value || typeof value !== "object") {
         return false
     }

--- a/test/useAsObservableSource.test.tsx
+++ b/test/useAsObservableSource.test.tsx
@@ -335,7 +335,24 @@ it("checks for plain object being passed in", () => {
     const restore = mockConsole() // to ignore React showing caught errors
     const { result } = renderHook(() => useAsObservableSource(false))
     expect(result.error).toMatchInlineSnapshot(
-        `[Error: useAsObservableSource expects an object as first argument]`
+        `[Error: useAsObservableSource expects a plain object as first argument]`
+    )
+    restore()
+})
+
+// https://github.com/mpeyper/react-hooks-testing-library/issues/74
+it.skip("checks for stable shape of object being passed in", async () => {
+    const restore = mockConsole() // to ignore React showing caught errors
+    const { result, rerender } = renderHook(
+        ({ second }) => {
+            const obj = second ? { foo: "brr", baz: "new" } : { foo: "baz" }
+            return useAsObservableSource(obj)
+        },
+        { initialProps: { second: false } }
+    )
+    rerender({ second: true })
+    expect(result.error).toMatchInlineSnapshot(
+        `[Error: the shape of objects passed to useAsObservableSource should be stable]`
     )
     restore()
 })

--- a/test/useLocalStore.test.tsx
+++ b/test/useLocalStore.test.tsx
@@ -247,15 +247,18 @@ describe("is used to keep observable within component body", () => {
             function Counter({ multiplier }: { multiplier: number }) {
                 counterRender++
 
-                const store = useLocalStore(props => ({
-                    count: 10,
-                    get multiplied() {
-                        return props.multiplier * this.count
-                    },
-                    inc() {
-                        this.count += 1
-                    }
-                }), { multiplier })
+                const store = useLocalStore(
+                    props => ({
+                        count: 10,
+                        get multiplied() {
+                            return props.multiplier * this.count
+                        },
+                        inc() {
+                            this.count += 1
+                        }
+                    }),
+                    { multiplier }
+                )
 
                 return useObserver(
                     () => (
@@ -311,15 +314,18 @@ describe("is used to keep observable within component body", () => {
             function Counter({ multiplier }: { multiplier: number }) {
                 counterRender++
 
-                const store = useLocalStore(props => ({
-                    count: 10,
-                    get multiplied() {
-                        return props.multiplier * this.count
-                    },
-                    inc() {
-                        this.count += 1
-                    }
-                }), { multiplier })
+                const store = useLocalStore(
+                    props => ({
+                        count: 10,
+                        get multiplied() {
+                            return props.multiplier * this.count
+                        },
+                        inc() {
+                            this.count += 1
+                        }
+                    }),
+                    { multiplier }
+                )
 
                 return (
                     <Observer>
@@ -376,15 +382,18 @@ describe("is used to keep observable within component body", () => {
             const Counter = observer(({ multiplier }: { multiplier: number }) => {
                 counterRender++
 
-                const store = useLocalStore(props => ({
-                    count: 10,
-                    get multiplied() {
-                        return props.multiplier * this.count
-                    },
-                    inc() {
-                        this.count += 1
-                    }
-                }), { multiplier })
+                const store = useLocalStore(
+                    props => ({
+                        count: 10,
+                        get multiplied() {
+                            return props.multiplier * this.count
+                        },
+                        inc() {
+                            this.count += 1
+                        }
+                    }),
+                    { multiplier }
+                )
 
                 return (
                     <div>
@@ -426,22 +435,23 @@ describe("is used to keep observable within component body", () => {
         })
     })
 
-
     it("checks for plain object being passed in", () => {
         const restore = mockConsole() // to ignore React showing caught errors
         const { result } = renderHook(() => {
-            useLocalStore(props => ({
-                count: 10,
-                inc() {
-                    this.count += 1
-                }
-            }), false)
+            useLocalStore(
+                props => ({
+                    count: 10,
+                    inc() {
+                        this.count += 1
+                    }
+                }),
+                false as any
+            )
         })
 
         expect(result.error).toMatchInlineSnapshot(
-            `[Error: useLocalStore expects an object as second argument]`
+            `[Error: useLocalStore expects a plain object as second argument]`
         )
         restore()
     })
-
 })

--- a/test/useLocalStore.test.tsx
+++ b/test/useLocalStore.test.tsx
@@ -1,9 +1,11 @@
+import mockConsole from "jest-mock-console"
 import * as mobx from "mobx"
 import * as React from "react"
+import { renderHook } from "react-hooks-testing-library"
 import { act, cleanup, fireEvent, render } from "react-testing-library"
 
-import { observer, useLocalStore, useObserver } from "../src"
-import { useEffect } from "react"
+import { Observer, observer, useLocalStore, useObserver } from "../src"
+import { useEffect, useState } from "react"
 import { autorun } from "mobx"
 
 afterEach(cleanup)
@@ -236,4 +238,210 @@ describe("is used to keep observable within component body", () => {
         fireEvent.click(div)
         expect(div.textContent).toBe("initial - 10later - 20")
     })
+
+    describe("with props", () => {
+        it("and useObserver", () => {
+            let counterRender = 0
+            let observerRender = 0
+
+            function Counter({ multiplier }: { multiplier: number }) {
+                counterRender++
+
+                const store = useLocalStore(props => ({
+                    count: 10,
+                    get multiplied() {
+                        return props.multiplier * this.count
+                    },
+                    inc() {
+                        this.count += 1
+                    }
+                }), { multiplier })
+
+                return useObserver(
+                    () => (
+                        observerRender++,
+                        (
+                            <div>
+                                Multiplied count: <span>{store.multiplied}</span>
+                                <button id="inc" onClick={store.inc}>
+                                    Increment
+                                </button>
+                            </div>
+                        )
+                    )
+                )
+            }
+
+            function Parent() {
+                const [multiplier, setMultiplier] = useState(1)
+
+                return (
+                    <div>
+                        <Counter multiplier={multiplier} />
+                        <button id="incmultiplier" onClick={() => setMultiplier(m => m + 1)} />
+                    </div>
+                )
+            }
+
+            const { container } = render(<Parent />)
+
+            expect(container.querySelector("span")!.innerHTML).toBe("10")
+            expect(counterRender).toBe(1)
+            expect(observerRender).toBe(1)
+
+            act(() => {
+                ;(container.querySelector("#inc")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("11")
+            expect(counterRender).toBe(2) // 1 would be better!
+            expect(observerRender).toBe(2)
+
+            act(() => {
+                ;(container.querySelector("#incmultiplier")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("22")
+            expect(counterRender).toBe(4) // TODO: avoid double rendering here!
+            expect(observerRender).toBe(4) // TODO: avoid double rendering here!
+        })
+
+        it("with <Observer>", () => {
+            let counterRender = 0
+            let observerRender = 0
+
+            function Counter({ multiplier }: { multiplier: number }) {
+                counterRender++
+
+                const store = useLocalStore(props => ({
+                    count: 10,
+                    get multiplied() {
+                        return props.multiplier * this.count
+                    },
+                    inc() {
+                        this.count += 1
+                    }
+                }), { multiplier })
+
+                return (
+                    <Observer>
+                        {() => {
+                            observerRender++
+                            return (
+                                <div>
+                                    Multiplied count: <span>{store.multiplied}</span>
+                                    <button id="inc" onClick={store.inc}>
+                                        Increment
+                                    </button>
+                                </div>
+                            )
+                        }}
+                    </Observer>
+                )
+            }
+
+            function Parent() {
+                const [multiplier, setMultiplier] = useState(1)
+
+                return (
+                    <div>
+                        <Counter multiplier={multiplier} />
+                        <button id="incmultiplier" onClick={() => setMultiplier(m => m + 1)} />
+                    </div>
+                )
+            }
+
+            const { container } = render(<Parent />)
+
+            expect(container.querySelector("span")!.innerHTML).toBe("10")
+            expect(counterRender).toBe(1)
+            expect(observerRender).toBe(1)
+
+            act(() => {
+                ;(container.querySelector("#inc")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("11")
+            expect(counterRender).toBe(1)
+            expect(observerRender).toBe(2)
+
+            act(() => {
+                ;(container.querySelector("#incmultiplier")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("22")
+            expect(counterRender).toBe(2)
+            expect(observerRender).toBe(3)
+        })
+
+        it("with observer()", () => {
+            let counterRender = 0
+
+            const Counter = observer(({ multiplier }: { multiplier: number }) => {
+                counterRender++
+
+                const store = useLocalStore(props => ({
+                    count: 10,
+                    get multiplied() {
+                        return props.multiplier * this.count
+                    },
+                    inc() {
+                        this.count += 1
+                    }
+                }), { multiplier })
+
+                return (
+                    <div>
+                        Multiplied count: <span>{store.multiplied}</span>
+                        <button id="inc" onClick={store.inc}>
+                            Increment
+                        </button>
+                    </div>
+                )
+            })
+
+            function Parent() {
+                const [multiplier, setMultiplier] = useState(1)
+
+                return (
+                    <div>
+                        <Counter multiplier={multiplier} />
+                        <button id="incmultiplier" onClick={() => setMultiplier(m => m + 1)} />
+                    </div>
+                )
+            }
+
+            const { container } = render(<Parent />)
+
+            expect(container.querySelector("span")!.innerHTML).toBe("10")
+            expect(counterRender).toBe(1)
+
+            act(() => {
+                ;(container.querySelector("#inc")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("11")
+            expect(counterRender).toBe(2)
+
+            act(() => {
+                ;(container.querySelector("#incmultiplier")! as any).click()
+            })
+            expect(container.querySelector("span")!.innerHTML).toBe("22")
+            expect(counterRender).toBe(4) // TODO: should be 3
+        })
+    })
+
+
+    it("checks for plain object being passed in", () => {
+        const restore = mockConsole() // to ignore React showing caught errors
+        const { result } = renderHook(() => {
+            useLocalStore(props => ({
+                count: 10,
+                inc() {
+                    this.count += 1
+                }
+            }), false)
+        })
+
+        expect(result.error).toMatchInlineSnapshot(
+            `[Error: useLocalStore expects an object as second argument]`
+        )
+        restore()
+    })
+
 })


### PR DESCRIPTION
A polished version of #142 made by @sheerun

A most notable change is the reuse of `useAsObservableSource` and improved Typescript. Also instead of calling it `props` it's named more universally `source`.