### PR TITLE
useObserver reaction dispose check

### DIFF
--- a/src/useObserver.ts
+++ b/src/useObserver.ts
@@ -1,5 +1,6 @@
 import { Reaction } from "mobx"
 import { useDebugValue, useRef } from "react"
+
 import { printDebugValue } from "./printDebugValue"
 import { isUsingStaticRendering } from "./staticRendering"
 import { useForceUpdate, useUnmount } from "./utils"
@@ -31,10 +32,16 @@ export function useObserver<T>(
         })
     }
 
+    const dispose = () => {
+        if (reaction.current && !reaction.current.isDisposed) {
+            reaction.current.dispose()
+        }
+    }
+
     useDebugValue(reaction, printDebugValue)
 
     useUnmount(() => {
-        reaction.current!.dispose()
+        dispose()
     })
 
     // render the original component, but have the
@@ -50,7 +57,7 @@ export function useObserver<T>(
         }
     })
     if (exception) {
-        reaction.current.dispose()
+        dispose()
         throw exception // re-throw any exceptions catched during rendering
     }
     return rendering


### PR DESCRIPTION
I would have thought that MobX would not be annoyed by double disposal, but I just ran into it during Cypress tests. I guess things are much faster there.

![image](https://user-images.githubusercontent.com/1096340/57853132-44fa9600-77e5-11e9-99a2-e77c0c2f2d82.png)

@mweststrate @RoystonS 