### PR TITLE
Remove object destructuring from optimizeForReactDOM/Native

### DIFF
--- a/optimizeForReactDom.js
+++ b/optimizeForReactDom.js
@@ -1,2 +1,2 @@
-const { unstable_batchedUpdates } = require("react-dom")
-require("./dist").optimizeScheduler(unstable_batchedUpdates)
+const ReactDOM = require("react-dom")
+require("./dist").optimizeScheduler(ReactDOM.unstable_batchedUpdates)

--- a/optimizeForReactNative.js
+++ b/optimizeForReactNative.js
@@ -1,2 +1,2 @@
-const { unstable_batchedUpdates } = require("react-native")
-require("./dist").optimizeScheduler(unstable_batchedUpdates)
+const ReactNative = require("react-native")
+require("./dist").optimizeScheduler(ReactNative.unstable_batchedUpdates)


### PR DESCRIPTION
Replaced object destructuring with a more conventional approach to fix issue #238.

It was crucial for `optimizeForReactDom.js` to provide support for IE11, but I also applied the same logic to `optimizeForReactNative.js` just to keep it consistent between the two files.