### PR TITLE
Preserve generics when using `observer`

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -6,10 +6,16 @@ export interface IObserverOptions {
     readonly forwardRef?: boolean
 }
 
+export function observer<P extends object, TRef = {}>(
+    baseComponent: React.RefForwardingComponent<TRef, P>,
+    options: IObserverOptions & { forwardRef: true }
+): React.MemoExoticComponent<
+    React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
+>
 export function observer<
     C extends React.RefForwardingComponent<TRef, P>,
     P extends object = C extends React.RefForwardingComponent<any, infer T> ? T : unknown,
-    TRef extends object = C extends React.RefForwardingComponent<infer T, any> ? T : unknown
+    TRef = C extends React.RefForwardingComponent<infer T, any> ? T : unknown
 >(
     baseComponent: C,
     options: IObserverOptions & { forwardRef: true }
@@ -17,6 +23,11 @@ export function observer<
     React.MemoExoticComponent<
         React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
     >
+
+export function observer<P extends object>(
+    baseComponent: React.FunctionComponent<P>,
+    options?: IObserverOptions & { forwardRef: false }
+): React.FunctionComponent<P>
 export function observer<
     C extends React.FunctionComponent<P>,
     P extends object = C extends React.FunctionComponent<infer T> ? T : unknown

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -6,16 +6,25 @@ export interface IObserverOptions {
     readonly forwardRef?: boolean
 }
 
-export function observer<P extends object, TRef = {}>(
-    baseComponent: React.RefForwardingComponent<TRef, P>,
+export function observer<
+    C extends React.RefForwardingComponent<TRef, P>,
+    P extends object = C extends React.RefForwardingComponent<any, infer T> ? T : unknown,
+    TRef extends object = C extends React.RefForwardingComponent<infer T, any> ? T : unknown
+>(
+    baseComponent: C,
     options: IObserverOptions & { forwardRef: true }
-): React.MemoExoticComponent<
-    React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
->
-export function observer<P extends object>(
-    baseComponent: React.FunctionComponent<P>,
-    options?: IObserverOptions
-): React.FunctionComponent<P>
+): C &
+    React.MemoExoticComponent<
+        React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
+    >
+export function observer<
+    C extends React.FunctionComponent<P>,
+    P extends object = C extends React.FunctionComponent<infer T> ? T : unknown
+>(
+    baseComponent: C,
+    options?: IObserverOptions & { forwardRef: false }
+): C & React.FunctionComponent<P>
+
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(
     baseComponent: React.RefForwardingComponent<TRef, P>,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -26,15 +26,12 @@ export function observer<
 
 export function observer<P extends object>(
     baseComponent: React.FunctionComponent<P>,
-    options?: IObserverOptions & { forwardRef: false }
+    options?: IObserverOptions
 ): React.FunctionComponent<P>
 export function observer<
     C extends React.FunctionComponent<P>,
     P extends object = C extends React.FunctionComponent<infer T> ? T : unknown
->(
-    baseComponent: C,
-    options?: IObserverOptions & { forwardRef: false }
-): C & React.FunctionComponent<P>
+>(baseComponent: C, options?: IObserverOptions): C & React.FunctionComponent<P>
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -12,26 +12,28 @@ export function observer<P extends object, TRef = {}>(
 ): React.MemoExoticComponent<
     React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
 >
-export function observer<
-    C extends React.RefForwardingComponent<TRef, P>,
-    P extends object = C extends React.RefForwardingComponent<any, infer T> ? T : unknown,
-    TRef = C extends React.RefForwardingComponent<infer T, any> ? T : unknown
->(
-    baseComponent: C,
-    options: IObserverOptions & { forwardRef: true }
-): C &
-    React.MemoExoticComponent<
-        React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
-    >
 
 export function observer<P extends object>(
     baseComponent: React.FunctionComponent<P>,
     options?: IObserverOptions
 ): React.FunctionComponent<P>
+
 export function observer<
-    C extends React.FunctionComponent<P>,
-    P extends object = C extends React.FunctionComponent<infer T> ? T : unknown
->(baseComponent: C, options?: IObserverOptions): C & React.FunctionComponent<P>
+    C extends React.FunctionComponent<any> | React.RefForwardingComponent<any>,
+    Options extends IObserverOptions
+>(
+    baseComponent: C,
+    options?: Options
+): Options extends { forwardRef: true }
+    ? C extends React.RefForwardingComponent<infer TRef, infer P>
+        ? C &
+              React.MemoExoticComponent<
+                  React.ForwardRefExoticComponent<
+                      React.PropsWithoutRef<P> & React.RefAttributes<TRef>
+                  >
+              >
+        : never /* forwardRef set for a non forwarding component */
+    : C & React.FunctionComponent
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -581,12 +581,12 @@ it("should hoist known statics only", () => {
 
     const wrapped = observer(MyHipsterComponent)
     expect(wrapped.displayName).toBe("MyHipsterComponent")
-    expect((wrapped as any).randomStaticThing).toEqual(3)
-    expect((wrapped as any).defaultProps).toEqual({ x: 3 })
-    expect((wrapped as any).propTypes).toEqual({ x: isNumber })
-    expect((wrapped as any).type).toBeInstanceOf(Function) // And not "Nope!"; this is the wrapped component, the property is introduced by memo
-    expect((wrapped as any).compare).toBe(null) // another memo field
-    expect((wrapped as any).render).toBe(undefined)
+    expect(wrapped.randomStaticThing).toEqual(3)
+    expect(wrapped.defaultProps).toEqual({ x: 3 })
+    expect(wrapped.propTypes).toEqual({ x: isNumber })
+    expect(wrapped.type).toBeInstanceOf(Function) // And not "Nope!"; this is the wrapped component, the property is introduced by memo
+    expect(wrapped.compare).toBe(null) // another memo field
+    expect(wrapped.render).toBe(undefined)
 })
 
 it("should have the correct displayName", () => {

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -658,6 +658,64 @@ test("parent / childs render in the right order", done => {
     done()
 })
 
+it("should preserve generic parameters", () => {
+    interface IColor {
+        name: string;
+        css: string;
+    }
+
+    interface ITestComponentProps<T> {
+        value: T;
+        callback: (value: T) => void;
+    }
+    const TestComponent = observer(<T extends unknown>(props: ITestComponentProps<T>) => {
+        return null
+    })
+
+    function callbackString(value: string) {
+        return;
+    }
+    function callbackColor(value: IColor) {
+        return;
+    }
+
+    render(<TestComponent value="1" callback={callbackString} />)
+    render(<TestComponent value={{ name: 'red', css: 'rgb(255, 0, 0)' }} callback={callbackColor} />)
+
+    // this test has no `expect` calls as it verifies whether such component compiles or not
+})
+
+it("should preserve generic parameters when forwardRef", () => {
+    interface IMethods {
+        focus(): void
+    }
+
+    interface IColor {
+        name: string
+        css: string
+    }
+
+    interface ITestComponentProps<T> {
+        value: T
+        callback: (value: T) => void
+    }
+    const TestComponent = observer(<T extends unknown>(props: ITestComponentProps<T>, ref: React.Ref<IMethods>) => {
+        return null
+    }, { forwardRef: true })
+
+    function callbackString(value: string) {
+        return;
+    }
+    function callbackColor(value: IColor) {
+        return;
+    }
+
+    render(<TestComponent value="1" callback={callbackString} />)
+    render(<TestComponent value={{ name: 'red', css: 'rgb(255, 0, 0)' }} callback={callbackColor} />)
+
+    // this test has no `expect` calls as it verifies whether such component compiles or not
+})
+
 // describe("206 - @observer should produce usefull errors if it throws", () => {
 //     const data = mobx.observable({ x: 1 })
 //     let renderCount = 0

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -671,6 +671,22 @@ it("should have overload for props with children", () => {
     // this test has no `expect` calls as it verifies whether such component compiles or not
 })
 
+it("should have overload for empty options", () => {
+    // empty options are not really making sense now, but we shouldn't rely on `forwardRef`
+    // being specified in case other options are added in the future
+
+    interface IProps {
+        value: string;
+    }
+    const TestComponent = observer<IProps>(({ value, children }) => {
+        return null
+    }, {})
+
+    render(<TestComponent value="1" />)
+
+    // this test has no `expect` calls as it verifies whether such component compiles or not
+})
+
 it("should have overload for props with children when forwardRef", () => {
     interface IMethods {
         focus(): void

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -658,6 +658,36 @@ test("parent / childs render in the right order", done => {
     done()
 })
 
+it("should have overload for props with children", () => {
+    interface IProps {
+        value: string;
+    }
+    const TestComponent = observer<IProps>(({ value, children }) => {
+        return null
+    })
+
+    render(<TestComponent value="1" />)
+
+    // this test has no `expect` calls as it verifies whether such component compiles or not
+})
+
+it("should have overload for props with children when forwardRef", () => {
+    interface IMethods {
+        focus(): void
+    }
+
+    interface IProps {
+        value: string;
+    }
+    const TestComponent = observer<IProps, IMethods>(({ value, children }, ref) => {
+        return null
+    }, { forwardRef: true })
+
+    render(<TestComponent value="1" />)
+
+    // this test has no `expect` calls as it verifies whether such component compiles or not
+})
+
 it("should preserve generic parameters", () => {
     interface IColor {
         name: string;


### PR DESCRIPTION
Related issue https://github.com/mobxjs/mobx-react-lite/issues/243

This change allows wrapping generic components while preserving generic parameters.

There is also unintended change that preserves all static types. This has mostly positive effect, though `$$typeof`, `type`, `compare`, and `render` (which are not copied over) remain with their original type if defined on base component. I didn't find a way to omit these properties as any kind of narrowing will cause generic parameters to be converted to `unknown`.