### PR TITLE
useMemo instead of useState

### DIFF
--- a/src/useLocalStore.ts
+++ b/src/useLocalStore.ts
@@ -10,7 +10,7 @@ export function useLocalStore<TStore extends Record<string, any>, TSource extend
 ): TStore {
     const source = useAsObservableSourceInternal<TSource | undefined>(current, true)
 
-    return React.useState(() => {
+    return React.useMemo(() => {
         const local = observable(initializer(source as TSource))
         if (isPlainObject(local)) {
             runInAction(() => {
@@ -24,7 +24,7 @@ export function useLocalStore<TStore extends Record<string, any>, TSource extend
             })
         }
         return local
-    })[0]
+    }, [])
 }
 
 // tslint:disable-next-line: ban-types


### PR DESCRIPTION
UseMemo is the React standard to run a function and return a computed value in the function component, UseState in work too but it is not best practice.
This change was tested and worked well.
Great regards
