### PR TITLE
chore: exclude unused files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,11 +6,14 @@ coverage/
 
 .vscode
 .rpt2_cache
+.rts2_cache_*
+.circleci
 .editorconfig
 .prettierignore
 .prettierrc
 .browserlistrc
 .travis.yml
+.size-limit.json
 
 empty.js
 build-rollup.js
@@ -19,6 +22,7 @@ jest.setup.js
 tsconfig.json
 tsconfig.build.json
 tslint.json
+renovate.json
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Hi, v1.5.1 includes all the caches inside `.rts2_cache_*` folders.
It seems v2.0.0 will remove it (https://github.com/mobxjs/mobx-react-lite/commit/c19b013c809ae367e600a6b8f79e0c9d530dccd5), however this commit makes v1.5.1 way too large (1.5M).
Would you mind to include this in `.npmignore` (though it will not be used in v2.0.0), and release a minor version v1.5.2, with these folders excluded?