### PR TITLE
Fix losing props for observer component

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -34,7 +34,7 @@ export function observer<
                   >
               >
         : never /* forwardRef set for a non forwarding component */
-    : C & React.FunctionComponent
+    : C extends React.FunctionComponent<infer P> ? C & React.FunctionComponent<P> : never /* observer uses for non functional component */
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -7,6 +7,18 @@ export interface IObserverOptions {
     readonly forwardRef?: boolean
 }
 
+export function observer<P extends object, TRef = {}>(
+    baseComponent: React.RefForwardingComponent<TRef, P>,
+    options: IObserverOptions & { forwardRef: true }
+): React.MemoExoticComponent<
+    React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
+>
+
+export function observer<P extends object>(
+    baseComponent: React.FunctionComponent<P>,
+    options?: IObserverOptions
+): React.FunctionComponent<P>
+
 export function observer<
     C extends React.FunctionComponent<any> | React.RefForwardingComponent<any>,
     Options extends IObserverOptions
@@ -15,13 +27,14 @@ export function observer<
     options?: Options
 ): Options extends { forwardRef: true }
     ? C extends React.RefForwardingComponent<infer TRef, infer P>
-        ? React.MemoExoticComponent<
-              React.ForwardRefExoticComponent<
-                  React.PropsWithoutRef<P> & React.RefAttributes<TRef>
+        ? C &
+              React.MemoExoticComponent<
+                  React.ForwardRefExoticComponent<
+                      React.PropsWithoutRef<P> & React.RefAttributes<TRef>
+                  >
               >
-          >
         : never /* forwardRef set for a non forwarding component */
-    : React.MemoExoticComponent<C>;
+    : C;
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -7,18 +7,6 @@ export interface IObserverOptions {
     readonly forwardRef?: boolean
 }
 
-export function observer<P extends object, TRef = {}>(
-    baseComponent: React.RefForwardingComponent<TRef, P>,
-    options: IObserverOptions & { forwardRef: true }
-): React.MemoExoticComponent<
-    React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<TRef>>
->
-
-export function observer<P extends object>(
-    baseComponent: React.FunctionComponent<P>,
-    options?: IObserverOptions
-): React.FunctionComponent<P>
-
 export function observer<
     C extends React.FunctionComponent<any> | React.RefForwardingComponent<any>,
     Options extends IObserverOptions
@@ -27,14 +15,13 @@ export function observer<
     options?: Options
 ): Options extends { forwardRef: true }
     ? C extends React.RefForwardingComponent<infer TRef, infer P>
-        ? C &
-              React.MemoExoticComponent<
-                  React.ForwardRefExoticComponent<
-                      React.PropsWithoutRef<P> & React.RefAttributes<TRef>
-                  >
+        ? React.MemoExoticComponent<
+              React.ForwardRefExoticComponent<
+                  React.PropsWithoutRef<P> & React.RefAttributes<TRef>
               >
+          >
         : never /* forwardRef set for a non forwarding component */
-    : C extends React.FunctionComponent<infer P> ? C & React.FunctionComponent<P> : never /* observer uses for non functional component */
+    : React.MemoExoticComponent<C>;
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -34,7 +34,7 @@ export function observer<
                   >
               >
         : never /* forwardRef set for a non forwarding component */
-    : C;
+    : C extends React.FunctionComponent<infer P> ? C & React.FunctionComponent<P> : never;
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(

--- a/test/observer.test.tsx
+++ b/test/observer.test.tsx
@@ -762,6 +762,23 @@ it("should preserve generic parameters when forwardRef", () => {
     // this test has no `expect` calls as it verifies whether such component compiles or not
 })
 
+it("should keep original props types", () => {
+    interface TestComponentProps {
+        a: number;
+    }
+
+    function TestComponent({ a }: TestComponentProps): JSX.Element | null {
+        return null;
+    }
+
+    const ObserverTestComponent = observer(TestComponent);
+
+    const element = React.createElement(ObserverTestComponent, { a: 1 });
+    render(element)
+
+    // this test has no `expect` calls as it verifies whether such component compiles or not
+})
+
 // describe("206 - @observer should produce usefull errors if it throws", () => {
 //     const data = mobx.observable({ x: 1 })
 //     let renderCount = 0


### PR DESCRIPTION
Some code in my project has broken after latest updates because resulting observer component type loose original props. Take a look at [example](https://www.typescriptlang.org/play/?jsx=2#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wG4BYAKCqQA9JY5gA7GJKTdJOASQHkARgGd2AN3Z8wMYBGZC4AbypwVcIigAmsgDYBPOJmgB3FFA3JMAfgBccARAjbUzCpQC+VGvWjwNSNNqm3JgArswYMsxwEMJi7AA8AApwdGzMGvIxAFb+MAA0cAAqFnAAvIpuAHwAFAIoIgDCuJDMSKy2yOgwAHQWAGLGphosAOZN4LJtMPHFSJgFiZUFEFKRQrb8sVDiUJLSsvIAZIrKqoZQJmYWtjBQIUiubgCUHcQ9ALJIIBAAorQQ0jQ4xaU3inQw3QGFyGFj+AOAQOak1YYLe3USODAQgA6sAYAALCAhGAWJKVODHcE9CwAQRgt2AAmJSCEMwslQ5ri8DF8-kCRAMYQismiWx2SRStDSGVFOQwNTqjSRrXaiDRfSF+2YwOR00Wy1WBxsvEEIm2EkNcheaq6kM1kR1Kr1lS5lDoPLgfgCQUF4S1orN4oakul8ipdr9DuVoJQzF05IAPjaIf1BmZRo6Y3GlnA9msQ20ZZtAxatUIFfUkJnVQ0DWXjXmDtbG3IC+l5EpKKoDGnzHMbncHlQ3HBLHBg6lC2G0anoenmGNoyiWJh2EULAUV2vFqPxxTkx8vr9-oDq9Nw1DLn3MHDT0vz2iMSscXjCcTSTvKTO5nSGUy2KysyYBy5K2K0OynCotjBl+toapGshnq43YAPQoXA0FtjKF72oh97xFuUBwDuY4wQeEbCtq+E7mBSA7K6VAsGwHBcHANJPliJxdqoKBgSEIACOwjyeJQoQIVENLVAocAoHAbi2OxmJCNaABSADKAAa3Q-E4IBTFx3ZEDAIRQFE8TDKIlQKCgbjxChFkusOIloAc8CmnEUA0mUAYedUNJPK6LlyPARBCCE2gwAAjN58ReShjmUEFQghSy4UwAATDF7nmp5cDxaQQA).

Correct type checking:
![image](https://user-images.githubusercontent.com/374240/78647305-3543de80-78dc-11ea-95df-351f379364b8.png)

Incorrect type checking (and children prop has appered):
![image](https://user-images.githubusercontent.com/374240/78647404-5f959c00-78dc-11ea-9696-808273990602.png)

Replace code:
![image](https://user-images.githubusercontent.com/374240/78647540-8f44a400-78dc-11ea-824f-0cb887ff04dc.png)

And type checking is correct:
![image](https://user-images.githubusercontent.com/374240/78647616-a84d5500-78dc-11ea-9d29-57241cda2217.png)
