### PR TITLE
observer() return type should be whatever the wrapped component is. 

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -34,7 +34,7 @@ export function observer<
                   >
               >
         : never /* forwardRef set for a non forwarding component */
-    : C extends React.FunctionComponent<infer P> ? C & React.FunctionComponent<P> : never;
+    : C & { displayName: string }
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(


### PR DESCRIPTION
One of the benefits of not hard coding to `React.FC` is no more implicit `children` prop. 

This makes it so any children expected to a component are declared explicit as part of the props type signature. 



So if your component expects children, it should either use 
`props: React.PropsWithChildren<MyProps>` 
or 
add `children?: React.ReactNode` to your interface.
The [benefits](https://github.com/facebook/create-react-app/pull/8177) are plenty. 
But apart form that, `JSX.Element` is what's inferred when you define a function component. The HOC shouldn't change that. 

This also reverts changes made in https://github.com/mobxjs/mobx-react-lite/pull/272 - which purposes I didn't quite understand, might be depending on Typescript versions, but requires further discussion and changes. 

Edit: merged `{displayName: string}` to the return type, since the tests were relying on them existing. 