### PR TITLE
observer() return type should be whatever the wrapped component is

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -34,7 +34,7 @@ export function observer<
                   >
               >
         : never /* forwardRef set for a non forwarding component */
-    : C extends React.FunctionComponent<infer P> ? C & React.FunctionComponent<P> : never;
+    : C & { displayName: string }
 
 // n.b. base case is not used for actual typings or exported in the typing files
 export function observer<P extends object, TRef = {}>(


### PR DESCRIPTION
Another try for #275 which CI ignored for some reason.