### PR TITLE
Allow setting default forceUpdate hook for useObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ interface IUseObserverOptions {
 
 It allows you to use an observer like behaviour, but still allowing you to optimize the component in any way you want (e.g. using memo with a custom areEqual, using forwardRef, etc.) and to declare exactly the part that is observed (the render phase).
 
+Instead of providing useForceUpdate option on every invocation, you can instead call setDefaultForceUpdate to override the default forceUpdate hook.
+
 ### **`useLocalStore<T, S>(initializer: () => T, source?: S): T`** _([user guide](https://mobx-react.js.org/state-local))_
 
 Local observable state can be introduced by using the useLocalStore hook, that runs its initializer function once to create an observable store and keeps it around for a lifetime of a component.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,12 @@ import "./assertEnvironment"
 
 export { isUsingStaticRendering, useStaticRendering } from "./staticRendering"
 export { observer, IObserverOptions } from "./observer"
-export { useObserver, ForceUpdateHook, IUseObserverOptions } from "./useObserver"
+export {
+    useObserver,
+    setDefaultForceUpdate,
+    ForceUpdateHook,
+    IUseObserverOptions
+} from "./useObserver"
 export { Observer } from "./ObserverComponent"
 export { useForceUpdate } from "./utils"
 export { useAsObservableSource } from "./useAsObservableSource"

--- a/src/useObserver.ts
+++ b/src/useObserver.ts
@@ -24,6 +24,12 @@ function observerComponentNameFor(baseComponentName: string) {
     return `observer${baseComponentName}`
 }
 
+let defaultForceUpdateHook = useForceUpdate
+
+export function setDefaultForceUpdate(forceUpdateHook: ForceUpdateHook) {
+    defaultForceUpdateHook = forceUpdateHook
+}
+
 let warnedAboutBatching = false
 
 export function useObserver<T>(
@@ -42,7 +48,7 @@ export function useObserver<T>(
         warnedAboutBatching = true
     }
 
-    const wantedForceUpdateHook = options.useForceUpdate || useForceUpdate
+    const wantedForceUpdateHook = options.useForceUpdate || defaultForceUpdateHook
     const forceUpdate = wantedForceUpdateHook()
 
     // StrictMode/ConcurrentMode/Suspense may mean that our component is

--- a/test/customForceUpdate.test.tsx
+++ b/test/customForceUpdate.test.tsx
@@ -1,7 +1,7 @@
 import { observable } from "mobx"
 import * as React from "react"
 import { act, cleanup, render } from "@testing-library/react"
-import { IUseObserverOptions, useForceUpdate, useObserver } from "../src"
+import { IUseObserverOptions, useForceUpdate, useObserver, setDefaultForceUpdate } from "../src"
 
 afterEach(cleanup)
 
@@ -23,6 +23,33 @@ it("a custom force update method can be used", () => {
 
     const TestComponent = () => {
         return useObserver(() => <div>{obs.get()}</div>, undefined, opts)
+    }
+
+    render(<TestComponent />)
+    expect(x).toBe(0)
+    act(() => {
+        obs.set(1) // the custom force update should be called here
+    })
+    expect(x).toBe(1)
+})
+
+it("a custom default force update method can be used", () => {
+    let x = 0
+
+    function useCustomForceUpdate() {
+        const update = useForceUpdate()
+        return () => {
+            x++
+            update()
+        }
+    }
+
+    setDefaultForceUpdate(useCustomForceUpdate)
+
+    const obs = observable.box(0)
+
+    const TestComponent = () => {
+        return useObserver(() => <div>{obs.get()}</div>)
     }
 
     render(<TestComponent />)


### PR DESCRIPTION
As the title says.

See also #274 

### Code change checklist

-   [x] Added/updated unit tests
-   [x] Updated `README` if applicable
