### PR TITLE
Add react-dom as an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "mobx": "^4.0.0 || ^5.0.0",
     "react": "^16.8.0"
   },
+  "optionalDependencies": {
+    "react-dom": "^16.8.0"
+  },
   "devDependencies": {
     "@babel/core": "7.8.4",
     "@babel/preset-env": "7.8.4",


### PR DESCRIPTION
Since [`batchingForReactDom.js`](https://github.com/mobxjs/mobx-react-lite/blob/45a58c42bdc4a511d55a512474fd34c4ca3afbcf/batchingForReactDom.js#L1) requires `react-dom` it should be listed as an [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies).

This fixes the following issue when used with Yarn v2:
```
Module not found: mobx-react-lite tried to access react-dom, but it isn't declared in its dependencies; this makes the 
require call ambiguous and unsound.
```