### PR TITLE
Remove sideEffects section, fixes #312

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
   "jsnext:main": "es/index.js",
   "react-native": "es/index.js",
   "types": "dist/index.d.ts",
-  "sideEffects": [
-    "batching*"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/mobxjs/mobx-react-lite.git"


### PR DESCRIPTION
See #312. Tree shaking should already do the correct thing in mobx-react-lite if API's are unused, so there is no need to mark certain modules explicitly as (not) side effect free.
