### PR TITLE
Update link to React integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It also doesn't offer
 
 `mobx-react-lite` requires React 16.8 or higher.
 
-## User Guide 👉 https://mobx.js.org/react/react-integration.html
+## User Guide 👉 https://mobx.js.org/react-integration.html
 
 ---
 


### PR DESCRIPTION
The "old" link points to a page, that only contains the hint "This document has been updated and moved" and forwards to the "new" link. So I think I makes sense to directly point to the "new" URL?