### PR TITLE
fix: expose function to clear timers and allow immediate test exit

### DIFF
--- a/.changeset/loud-starfishes-shave.md
+++ b/.changeset/loud-starfishes-shave.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-lite": patch
+---
+
+expose `clearTimers` function to tidy up background timers, allowing test frameworks such as Jest to exit immediately

--- a/.changeset/loud-starfishes-shave.md
+++ b/.changeset/loud-starfishes-shave.md
@@ -1,5 +1,5 @@
 ---
-"mobx-react-lite": patch
+"mobx-react-lite": minor
 ---
 
 expose `clearTimers` function to tidy up background timers, allowing test frameworks such as Jest to exit immediately

--- a/README.md
+++ b/README.md
@@ -154,3 +154,19 @@ Above imports are for a convenience to utilize standard versions of batching. If
 import { observerBatching } from "mobx-react-lite"
 observerBatching(customBatchedUpdates)
 ```
+
+## Testing
+
+In order to avoid memory leaks due to aborted renders from React
+fiber handling or React `StrictMode`, this library needs to
+run timers to tidy up the remains of the aborted renders.
+
+This can cause issues with test frameworks such as Jest
+which require that timers be cleaned up before the tests
+can exit.
+
+### **`clearTimers()**
+
+Call `clearTimers()` in the `afterEach` of your tests to ensure
+that `mobx-react-lite` cleans up immediately and allows tests
+to exit.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { Observer } from "./ObserverComponent"
 export { useLocalObservable } from "./useLocalObservable"
 export { useLocalStore } from "./useLocalStore"
 export { useAsObservableSource } from "./useAsObservableSource"
+export { resetCleanupScheduleForTests as clearTimers } from "./utils/reactionCleanupTracking"
 
 export function useObserver<T>(fn: () => T, baseComponentName: string = "observed"): T {
     if ("production" !== process.env.NODE_ENV) {

--- a/src/utils/reactionCleanupTracking.ts
+++ b/src/utils/reactionCleanupTracking.ts
@@ -119,9 +119,19 @@ export function forceCleanupTimerToRunNowForTests() {
 
 /* istanbul ignore next */
 export function resetCleanupScheduleForTests() {
+    if (uncommittedReactionRefs.size > 0) {
+        for (const ref of uncommittedReactionRefs) {
+            const tracking = ref.current
+            if (tracking) {
+                tracking.reaction.dispose()
+                ref.current = null
+            }
+        }
+        uncommittedReactionRefs.clear()
+    }
+
     if (reactionCleanupHandle) {
         clearTimeout(reactionCleanupHandle)
         reactionCleanupHandle = undefined
     }
-    uncommittedReactionRefs.clear()
 }


### PR DESCRIPTION
Exposes `clearTimers` function which clears up background
'aborted render' reactions immediately.  Some test frameworks
such as Jest prevent exit unless all such timers are cleared.

For: mobxjs/mobx#2528

### Code change checklist

-   [ ] Added/updated unit tests  N/A
-   [x] Updated `README` if applicable
