### PR TITLE
Remove incomplete sentence from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 This is a lighter version of [mobx-react](https://github.com/mobxjs/mobx-react) which supports React **functional components only** and as such makes the library slightly faster and smaller (_only 1.5kB gzipped_). Note however that it is possible to use `<Observer>` inside the render of class components.
 Unlike `mobx-react`, it doesn't `Provider`/`inject`, as `useContext` can be used instead.
-It also doesn't offer
 
 ## Compatibility table (major versions)
 


### PR DESCRIPTION
<!--
    Thanks for taking the effort to create a PR!
-->

Removes the incomplete "It also doesn't offer" sentence from the README intro.

This PR would be better solved by finishing the sentence, but I don't have the knowledge to complete what it might have been intending to say. If you let me know, I can update the PR!

Thanks for the library :)